### PR TITLE
Reset metrics details when setting details option.

### DIFF
--- a/types.go
+++ b/types.go
@@ -272,7 +272,7 @@ func WithNamespace(namespace string) option {
 
 func WithDetails(details trace.Details) option {
 	return func(c *config) {
-		c.details |= details
+		c.details = details
 	}
 }
 


### PR DESCRIPTION
When we using `|=` in `WithDetails` option we always get `DetailsAll` in metrics config,
Because we use `DetailsAll` as default value in the config and any bitwise or with this value does not change anything.
We need to completely reset `config.details` value when we applying `WithDetails` option.